### PR TITLE
Enhance analytics filter normalization and query processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ STEP*
 STEP*.md
 BRD*.md
 docs/brd/
+analytics-plan.md

--- a/backend/analytics/filter_value_normalizer.py
+++ b/backend/analytics/filter_value_normalizer.py
@@ -99,6 +99,23 @@ def _normalize_scalar_value(
     return matched if matched is not None else value
 
 
+def _year_equals_to_eq_on_integer(
+    filt: AnalyticsFilter,
+    column_metadata: dict[str, ColumnMetadata],
+) -> AnalyticsFilter | None:
+    """Map year_equals on an integer column to eq(year): validators only allow year_equals on dates."""
+    if filt.operator != "year_equals" or filt.value is None:
+        return None
+    meta = column_metadata.get(filt.column)
+    if meta is None or meta.logical_type != "integer":
+        return None
+    try:
+        y = int(filt.value)
+    except (TypeError, ValueError):
+        return None
+    return AnalyticsFilter(column=filt.column, operator="eq", value=y)
+
+
 def normalize_analytics_plan_filters(
     plan: AnalyticsPlan,
     column_metadata: dict[str, ColumnMetadata],
@@ -106,11 +123,21 @@ def normalize_analytics_plan_filters(
     conn: sqlite3.Connection | None,
     table_name: str | None,
 ) -> AnalyticsPlan:
-    """Return a copy of plan with string eq/neq filter values aligned to actual cell text."""
+    """Return a copy of plan with repaired filters.
+
+    - year_equals on integer columns (e.g. Year) becomes eq; planners often emit
+      year_equals for calendar-year filters, but validation only allows it on date columns.
+    - String eq/neq values are aligned to actual cell text where possible.
+    """
     original_to_safe = {m.original_name: m.safe_name for m in column_metadata.values()}
     new_filters: list[AnalyticsFilter] = []
     changed = False
     for filt in plan.filters:
+        repaired = _year_equals_to_eq_on_integer(filt, column_metadata)
+        if repaired is not None:
+            changed = True
+            filt = repaired
+
         if filt.operator not in ("eq", "neq"):
             new_filters.append(filt)
             continue

--- a/backend/analytics/query_decomposer.py
+++ b/backend/analytics/query_decomposer.py
@@ -237,7 +237,14 @@ class QueryDecomposer:
             "For 'who buys the most', use groupby_sum on a quantity/revenue column.\n"
             "- For 'which/who + superlative + metric', use groupby_sum with order=value_desc, top_n=1.\n"
             "- Column names must be ORIGINAL header names from the list above.\n"
-            "- Map user phrases to KNOWN CATEGORICAL VALUES (e.g. 'fruits' -> 'Fruits').\n\n"
+            "- Map user phrases to KNOWN CATEGORICAL VALUES (e.g. 'fruits' -> 'Fruits').\n"
+            "- Total or sum for a calendar year: use operation sum on the money column; if there is an "
+            "integer Year column, filter with operator eq and integer value (e.g. 2025). Use year_equals "
+            "only on columns typed as date in AVAILABLE COLUMNS (e.g. OrderDate). Never use year_equals "
+            "on integer or string columns.\n"
+            "- Example (replace names with actual headers): total revenue in 2025 → intent analytics, "
+            "analytics_plan with operation sum, target_column set to the revenue column, "
+            'filters [{"column":"Year","operator":"eq","value":2025}] when Year is integer.\n\n'
         )
 
     def _forecast_plan_schema(self, summary: DatasetSummary) -> str:

--- a/backend/services/chat/analytics_runner.py
+++ b/backend/services/chat/analytics_runner.py
@@ -173,7 +173,7 @@ class AnalyticsChatRunner:
             chart=chart_spec,
         )
 
-    async def execute_analytics_plan(self, plan: AnalyticsPlan) -> ChatResult | None:
+    async def execute_analytics_plan(self, plan: AnalyticsPlan) -> ChatResult:
         try:
             result = await asyncio.to_thread(self._analytics_executor.execute, plan)
             answer = self.format_deterministic_analytics_answer(result)
@@ -185,7 +185,15 @@ class AnalyticsChatRunner:
             )
         except AnalyticsError as exc:
             logger.warning("Analytics execution failed: %s", exc)
-            return None
+            return ChatResult(
+                answer=(
+                    "I could not run that analysis on your spreadsheet. "
+                    "Try rephrasing the question or check that filters match the file columns."
+                ),
+                mode="OFFLINE_ARCHIVE",
+                contexts=[],
+                attached_sources=None,
+            )
 
     async def generate_analytics_plan(
         self, *, user_query: str, document_id: str

--- a/backend/services/chat/intents.py
+++ b/backend/services/chat/intents.py
@@ -58,6 +58,37 @@ _FILENAME_IN_PATTERN = re.compile(
 
 _LAST_PATTERN = re.compile(r"\b(?:last|final|latest|most recent|bottom)\b", re.IGNORECASE)
 
+_STRIP_FILENAME_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"\b(?:in|from|of)\s+(?:the\s+)?['\"]?"
+        r"[a-zA-Z0-9_\-]+(?:-\d+)?(?:\.[a-zA-Z0-9]+)?"
+        r"['\"]?\s+(?:file|document|spreadsheet|workbook|sheet|dataset)\s*\??",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bfrom\s+(?:the\s+)?['\"]?"
+        r"[a-zA-Z0-9_\-]+(?:-\d+)?(?:\.[a-zA-Z0-9]+)?"
+        r"['\"]?\s*(?:file|document|spreadsheet|workbook|sheet|dataset)?",
+        re.IGNORECASE,
+    ),
+]
+
+
+def strip_filename_from_query(query: str) -> str:
+    """Remove filename references so the LLM decomposer sees only the analytical question.
+
+    The document is already selected via ``document_ids``; leaving the
+    filename in the prompt causes the LLM to misinterpret it as a filter
+    or column reference.
+    """
+    cleaned = query
+    for pat in _STRIP_FILENAME_PATTERNS:
+        cleaned = pat.sub("", cleaned)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip().rstrip("?").strip()
+    if cleaned:
+        cleaned += "?"
+    return cleaned if cleaned else query
+
 
 def _detect_filename(query: str) -> str | None:
     """Extract filename from query, preferring 'from FILE' over 'in FILE file'."""

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -41,6 +41,7 @@ from .chat.analytics_planning import (
 )
 from .chat.analytics_runner import AnalyticsChatRunner
 from .chat.context import ChatRetrievalDeps, gather_contexts
+from .chat.intents import strip_filename_from_query
 from .chat.prompts import answer_prompt, extraction_prompt, has_usable_context
 from .chat.types import ChatResult, StreamEvent
 
@@ -202,8 +203,10 @@ class ChatService:
         if summary is None:
             return None
 
+        cleaned_query = strip_filename_from_query(query)
+
         try:
-            plan = await self._decomposer.decompose(query, summary)
+            plan = await self._decomposer.decompose(cleaned_query, summary)
         except Exception as exc:
             logger.warning("Query decomposition failed: %s", exc)
             return None
@@ -314,8 +317,10 @@ class ChatService:
         if summary is None:
             return None
 
+        cleaned_query = strip_filename_from_query(query)
+
         try:
-            plan = await self._decomposer.decompose(query, summary)
+            plan = await self._decomposer.decompose(cleaned_query, summary)
         except Exception as exc:
             logger.warning("Stream query decomposition failed: %s", exc)
             return None

--- a/tests/test_analytics_deterministic.py
+++ b/tests/test_analytics_deterministic.py
@@ -35,7 +35,7 @@ from backend.analytics.filter_value_normalizer import normalize_analytics_plan_f
 from backend.analytics.router import AnalyticsRouter
 from backend.analytics.validator import validate_plan, validate_result
 from backend.analytics.errors import AnalyticsPlanValidationError
-from backend.documents import _infer_logical_type, _normalize_cell_value
+from backend.analytics.standardizer import infer_logical_type, normalize_cell
 from backend.services.chat_service import (
     apply_select_rows_limit_from_user_query,
     infer_select_rows_limit_from_query,
@@ -122,39 +122,39 @@ def in_memory_db() -> sqlite3.Connection:
 class TestTypeInference:
     def test_date_column(self):
         s = pd.Series([datetime(2020, 1, 1), datetime(2021, 6, 15), None])
-        assert _infer_logical_type(s) == "date"
+        assert infer_logical_type(s) == "date"
 
     def test_integer_column(self):
         s = pd.Series([1, 2, 3, 4])
-        assert _infer_logical_type(s) == "integer"
+        assert infer_logical_type(s) == "integer"
 
     def test_float_column(self):
         s = pd.Series([1.1, 2.2, 3.3])
-        assert _infer_logical_type(s) == "float"
+        assert infer_logical_type(s) == "float"
 
     def test_boolean_column(self):
         s = pd.Series([True, False, True])
-        assert _infer_logical_type(s) == "boolean"
+        assert infer_logical_type(s) == "boolean"
 
     def test_string_column(self):
         s = pd.Series(["hello", "world", "test"])
-        assert _infer_logical_type(s) == "string"
+        assert infer_logical_type(s) == "string"
 
     def test_string_dates_detected(self):
         s = pd.Series(["2020-01-15", "2021-06-30", "2022-12-01"])
-        assert _infer_logical_type(s) == "date"
+        assert infer_logical_type(s) == "date"
 
     def test_empty_series_defaults_to_string(self):
         s = pd.Series([], dtype=object)
-        assert _infer_logical_type(s) == "string"
+        assert infer_logical_type(s) == "string"
 
     def test_currency_strings_infer_as_float(self):
         s = pd.Series(["$1,234.56", "$2,000.00", "(100.25)", "€500"])
-        assert _infer_logical_type(s) == "float"
+        assert infer_logical_type(s) == "float"
 
     def test_currency_strings_infer_as_integer_when_whole_units(self):
         s = pd.Series([f"${i:,}" for i in range(1, 11)])
-        assert _infer_logical_type(s) == "integer"
+        assert infer_logical_type(s) == "integer"
 
 
 # ============================================================================
@@ -164,38 +164,38 @@ class TestTypeInference:
 class TestCellNormalization:
     def test_date_to_epoch(self):
         d = datetime(2020, 1, 1)
-        epoch = _normalize_cell_value(d, "date")
+        epoch = normalize_cell(d, "date")
         expected = int(datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp())
         assert epoch == expected
 
     def test_none_returns_none(self):
-        assert _normalize_cell_value(None, "date") is None
+        assert normalize_cell(None, "date") is None
 
     def test_boolean_true(self):
-        assert _normalize_cell_value(True, "boolean") == 1
+        assert normalize_cell(True, "boolean") == 1
 
     def test_boolean_false(self):
-        assert _normalize_cell_value(False, "boolean") == 0
+        assert normalize_cell(False, "boolean") == 0
 
     def test_integer(self):
-        assert _normalize_cell_value("42", "integer") == 42
+        assert normalize_cell("42", "integer") == 42
 
     def test_float(self):
-        assert _normalize_cell_value("3.14", "float") == pytest.approx(3.14)
+        assert normalize_cell("3.14", "float") == pytest.approx(3.14)
 
     def test_string_trim(self):
-        assert _normalize_cell_value("  hello  ", "string") == "hello"
+        assert normalize_cell("  hello  ", "string") == "hello"
 
     def test_date_string_to_epoch(self):
-        epoch = _normalize_cell_value("2020-06-15", "date")
+        epoch = normalize_cell("2020-06-15", "date")
         expected = int(datetime(2020, 6, 15, tzinfo=timezone.utc).timestamp())
         assert epoch == expected
 
     def test_currency_string_normalizes_to_float(self):
-        assert _normalize_cell_value("$1,234.50", "float") == pytest.approx(1234.5)
+        assert normalize_cell("$1,234.50", "float") == pytest.approx(1234.5)
 
     def test_accounting_negative_parentheses_to_float(self):
-        assert _normalize_cell_value("(99.5)", "float") == pytest.approx(-99.5)
+        assert normalize_cell("(99.5)", "float") == pytest.approx(-99.5)
 
 
 # ============================================================================
@@ -488,7 +488,7 @@ class TestEndToEnd:
         headers = list(sample_df.columns)
         col_types = {}
         for h in headers:
-            col_types[h] = _infer_logical_type(sample_df[h])
+            col_types[h] = infer_logical_type(sample_df[h])
 
         safe_names = {h: f"col_{h.lower().replace(' ', '_')}" for h in headers}
 
@@ -511,7 +511,7 @@ class TestEndToEnd:
         for _, row in sample_df.iterrows():
             values = []
             for h in headers:
-                values.append(_normalize_cell_value(row[h], col_types[h]))
+                values.append(normalize_cell(row[h], col_types[h]))
             conn.execute(f"INSERT INTO {table_name} ({safe_cols_sql}) VALUES ({placeholders});", values)
         conn.commit()
 
@@ -855,6 +855,56 @@ def test_normalize_filter_maps_user_phrase_to_profile_value():
     assert keys == {"ES", "US"}
 
 
+def test_normalize_year_equals_on_integer_year_becomes_eq_and_sum_runs():
+    """LLMs often emit year_equals on a spreadsheet Year column; only date columns allow it."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE sales (c_year INTEGER, c_rev REAL)")
+    conn.executemany(
+        "INSERT INTO sales VALUES (?,?)",
+        [(2024, 10.0), (2025, 100.0), (2025, 50.0)],
+    )
+    col_meta = {
+        "Year": ColumnMetadata("Year", "integer", "INTEGER", True, "Year", "c_year"),
+        "Revenue": ColumnMetadata("Revenue", "float", "REAL", True, "Revenue", "c_rev"),
+    }
+    plan = AnalyticsPlan(
+        document_id="d1",
+        operation="sum",
+        target_column="Revenue",
+        filters=[AnalyticsFilter(column="Year", operator="year_equals", value=2025)],
+    )
+    with pytest.raises(AnalyticsPlanValidationError):
+        validate_plan(plan, col_meta)
+
+    out = normalize_analytics_plan_filters(plan, col_meta, None, None, None)
+    assert out.filters[0].operator == "eq"
+    assert out.filters[0].value == 2025
+    validate_plan(out, col_meta)
+    compiled = compile_plan(out, table_name="sales", column_metadata=col_meta)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(compiled.sql, tuple(compiled.parameters)).fetchone()
+    assert row["sum_value"] == pytest.approx(150.0)
+
+
+def test_normalize_year_equals_on_date_column_not_rewritten():
+    col_meta = {
+        "OrderDate": ColumnMetadata(
+            "OrderDate", "date", "INTEGER", True, "OrderDate", "c_od"
+        ),
+        "Revenue": ColumnMetadata("Revenue", "float", "REAL", True, "Revenue", "c_rev"),
+    }
+    plan = AnalyticsPlan(
+        document_id="d1",
+        operation="sum",
+        target_column="Revenue",
+        filters=[AnalyticsFilter(column="OrderDate", operator="year_equals", value=2025)],
+    )
+    out = normalize_analytics_plan_filters(plan, col_meta, None, None, None)
+    assert out is plan or out.filters[0].operator == "year_equals"
+    assert out.filters[0].operator == "year_equals"
+    validate_plan(out, col_meta)
+
+
 class TestAnalyticsRouterExpanded:
     def test_monthly_sales_trend_routes(self):
         r = AnalyticsRouter()
@@ -1035,3 +1085,64 @@ def test_format_markdown_time_bucket_value_columns():
     md = format_analytics_result_markdown(ar, {})
     assert "| period | value |" in md
     assert "2024-01" in md
+
+
+# ============================================================================
+# strip_filename_from_query (analytics decomposer pre-processing)
+# ============================================================================
+
+
+from backend.services.chat.intents import strip_filename_from_query as _strip_filename
+
+
+class TestStripFilenameFromQuery:
+    def test_removes_in_filename_file(self):
+        q = "What is the total revenue in 2025 in Advanced_Sales_Dataset file ?"
+        out = _strip_filename(q)
+        assert "Advanced_Sales_Dataset" not in out
+        assert "total revenue" in out
+        assert "2025" in out
+        assert out.endswith("?")
+
+    def test_removes_in_filename_spreadsheet(self):
+        q = "What is the total revenue in 2025 in Advanced_Sales_Dataset spreadsheet?"
+        out = _strip_filename(q)
+        assert "Advanced_Sales_Dataset" not in out
+        assert "2025" in out
+
+    def test_removes_from_filename(self):
+        q = "Show revenue from Sales-Data-2025 file"
+        out = _strip_filename(q)
+        assert "Sales-Data-2025" not in out
+        assert "revenue" in out.lower()
+
+    def test_removes_of_filename_dataset(self):
+        q = "Total profit of my_report dataset"
+        out = _strip_filename(q)
+        assert "my_report" not in out
+        assert "profit" in out.lower()
+
+    def test_preserves_query_without_filename(self):
+        q = "What is the total revenue in 2025?"
+        out = _strip_filename(q)
+        assert "total revenue" in out
+        assert "2025" in out
+        assert out.endswith("?")
+
+    def test_preserves_in_keyword_for_year(self):
+        q = "Total sales in 2024?"
+        out = _strip_filename(q)
+        assert "2024" in out
+        assert "sales" in out.lower()
+
+    def test_removes_filename_with_extension(self):
+        q = "What is the average price in Sales_Data.xlsx file?"
+        out = _strip_filename(q)
+        assert "Sales_Data" not in out
+        assert "average price" in out
+
+    def test_removes_quoted_filename(self):
+        q = "Total units in 'Advanced_Sales_Dataset' file?"
+        out = _strip_filename(q)
+        assert "Advanced_Sales_Dataset" not in out
+        assert "units" in out.lower()


### PR DESCRIPTION
- Introduced a new function to map `year_equals` on integer columns to `eq`, ensuring proper validation and execution of analytics plans.
- Updated `normalize_analytics_plan_filters` to handle year-based filters correctly, improving compatibility with integer columns.
- Enhanced `ChatService` to strip filename references from user queries, preventing misinterpretation during query decomposition.
- Refactored tests to validate the new filter normalization logic and ensure robust handling of various data types.