### PR TITLE
Implement groupby_avg operation in analytics

### DIFF
--- a/backend/analytics/executor.py
+++ b/backend/analytics/executor.py
@@ -134,7 +134,7 @@ class AnalyticsExecutor:
                     out_rows.append({"key": d["key"], "count": int(d["cnt"])})
             return {"rows": out_rows}
 
-        if plan.operation in ("groupby_sum", "groupby_ratio"):
+        if plan.operation in ("groupby_sum", "groupby_avg", "groupby_ratio"):
             out_rows = []
             for r in rows:
                 d = dict(r)
@@ -189,6 +189,17 @@ class AnalyticsExecutor:
                 )
             return (
                 f"Computed group-by sums of '{plan.target_column}' by "
+                f"'{plan.group_by}' (top {plan.top_n})."
+            )
+        if op == "groupby_avg":
+            if plan.time_grain and plan.time_grain != "none":
+                g = plan.group_by or "(time only)"
+                return (
+                    f"Computed averages of '{plan.target_column}' over {plan.time_grain} "
+                    f"buckets by '{g}' (top {plan.top_n})."
+                )
+            return (
+                f"Computed group-by averages of '{plan.target_column}' by "
                 f"'{plan.group_by}' (top {plan.top_n})."
             )
         if op == "groupby_ratio":

--- a/backend/analytics/models.py
+++ b/backend/analytics/models.py
@@ -19,6 +19,7 @@ AnalyticsOperation = Literal[
     "max",
     "groupby_count",
     "groupby_sum",
+    "groupby_avg",
     "groupby_ratio",
     "select_rows",
 ]

--- a/backend/analytics/query_decomposer.py
+++ b/backend/analytics/query_decomposer.py
@@ -214,7 +214,7 @@ class QueryDecomposer:
             "{\n"
             f'  "document_id": {json.dumps(summary.document_id)},\n'
             '  "operation": "<count_rows | count_distinct | sum | avg | min | max | '
-            'groupby_count | groupby_sum | groupby_ratio | select_rows>",\n'
+            'groupby_count | groupby_sum | groupby_avg | groupby_ratio | select_rows>",\n'
             '  "target_column": "<column or null>",\n'
             '  "group_by": "<column or null>",\n'
             '  "time_column": "<date column or null>",\n'
@@ -232,10 +232,13 @@ class QueryDecomposer:
             "- Allowed filter operators: eq, neq, gt, gte, lt, lte, contains, startswith, "
             "year_equals (int year), month_equals (YYYY-MM), between_dates ([start, end]), "
             "is_null, is_not_null.\n"
-            "- target_column is REQUIRED for count_distinct, sum, avg, min, max, groupby_sum, groupby_ratio.\n"
+            "- target_column is REQUIRED for count_distinct, sum, avg, min, max, groupby_sum, groupby_avg, groupby_ratio.\n"
             "- groupby_count counts ROWS — use it only for 'how many orders/transactions'. "
             "For 'who buys the most', use groupby_sum on a quantity/revenue column.\n"
             "- For 'which/who + superlative + metric', use groupby_sum with order=value_desc, top_n=1.\n"
+            "- For 'average <metric> by <dimension>' or 'which <dimension> has the highest/lowest/min/max "
+            "average <metric>', use groupby_avg with target_column=<metric>, group_by=<dimension>. "
+            "Use order=value_asc for lowest/min average, order=value_desc for highest/max average.\n"
             "- Column names must be ORIGINAL header names from the list above.\n"
             "- Map user phrases to KNOWN CATEGORICAL VALUES (e.g. 'fruits' -> 'Fruits').\n"
             "- Total or sum for a calendar year: use operation sum on the money column; if there is an "

--- a/backend/analytics/sql_compiler.py
+++ b/backend/analytics/sql_compiler.py
@@ -358,6 +358,75 @@ def compile_plan(
         )
         return CompiledSql(sql=sql, parameters=params)
 
+    if plan.operation == "groupby_avg":
+        _require_target(plan)
+        top_n = max(1, min(plan.top_n, 1000))
+        use_time = plan.time_grain and plan.time_grain != "none"
+        if use_time:
+            if not plan.time_column:
+                raise AnalyticsCompilationError(
+                    "time_column is required when time_grain is set"
+                )
+            tmeta = column_metadata.get(plan.time_column)
+            if not tmeta or tmeta.logical_type != "date":
+                raise AnalyticsCompilationError(
+                    f"time_column '{plan.time_column}' must be a date column"
+                )
+            safe_t = _safe_col(plan.time_column, column_metadata, original_to_safe)
+            tb = _time_bucket_expr(safe_t, plan.time_grain)
+            safe_target_col = _safe_col(plan.target_column, column_metadata, original_to_safe)
+            if plan.group_by:
+                safe_group_col = _safe_col(plan.group_by, column_metadata, original_to_safe)
+                order_sql = {
+                    "value_desc": "value DESC",
+                    "value_asc": "value ASC",
+                    "count_desc": "value DESC",
+                    "count_asc": "value ASC",
+                    "key_asc": f"{safe_group_col} ASC",
+                    "key_desc": f"{safe_group_col} DESC",
+                }[plan.order]
+                sql = (
+                    f"SELECT {tb} AS time_bucket, {safe_group_col} AS key, "
+                    f"AVG({safe_target_col}) AS value "
+                    f"FROM {table_name} {where_sql} "
+                    f"GROUP BY 1, 2 "
+                    f"ORDER BY time_bucket ASC, {order_sql} "
+                    f"LIMIT {top_n};"
+                )
+                return CompiledSql(sql=sql, parameters=params)
+            sql = (
+                f"SELECT {tb} AS time_bucket, AVG({safe_target_col}) AS value "
+                f"FROM {table_name} {where_sql} "
+                f"GROUP BY 1 "
+                f"ORDER BY time_bucket ASC "
+                f"LIMIT {top_n};"
+            )
+            return CompiledSql(sql=sql, parameters=params)
+        if not plan.group_by:
+            raise AnalyticsCompilationError("groupby_avg requires group_by")
+
+        safe_group_col = _safe_col(plan.group_by, column_metadata, original_to_safe)
+        safe_target_col = _safe_col(plan.target_column, column_metadata, original_to_safe)
+
+        order_sql = {
+            "value_desc": "value DESC",
+            "value_asc": "value ASC",
+            "count_desc": "value DESC",
+            "count_asc": "value ASC",
+            "key_asc": f"{safe_group_col} ASC",
+            "key_desc": f"{safe_group_col} DESC",
+        }[plan.order]
+
+        sql = (
+            f"SELECT {safe_group_col} AS key, AVG({safe_target_col}) AS value "
+            f"FROM {table_name} "
+            f"{where_sql} "
+            f"GROUP BY {safe_group_col} "
+            f"ORDER BY {order_sql} "
+            f"LIMIT {top_n};"
+        )
+        return CompiledSql(sql=sql, parameters=params)
+
     if plan.operation == "groupby_ratio":
         _require_target(plan)
         if not plan.group_by:

--- a/backend/analytics/validator.py
+++ b/backend/analytics/validator.py
@@ -25,9 +25,10 @@ _OPS_REQUIRING_TARGET = {
     "min",
     "max",
     "groupby_sum",
+    "groupby_avg",
     "groupby_ratio",
 }
-_NUMERIC_AGGREGATES = {"sum", "avg", "groupby_sum", "groupby_ratio"}
+_NUMERIC_AGGREGATES = {"sum", "avg", "groupby_sum", "groupby_avg", "groupby_ratio"}
 
 
 def validate_plan(
@@ -70,9 +71,9 @@ def validate_plan(
             )
 
     tg = getattr(plan, "time_grain", "none") or "none"
-    if tg != "none" and plan.operation not in ("groupby_sum", "groupby_count"):
+    if tg != "none" and plan.operation not in ("groupby_sum", "groupby_avg", "groupby_count"):
         raise AnalyticsPlanValidationError(
-            "time_grain is only supported for groupby_sum and groupby_count"
+            "time_grain is only supported for groupby_sum, groupby_avg, and groupby_count"
         )
     if tg != "none" and not plan.time_column:
         raise AnalyticsPlanValidationError("time_grain requires time_column")
@@ -98,9 +99,9 @@ def validate_plan(
                 f"group_by column '{group_col}' not found in columns"
             )
 
-    if plan.operation == "groupby_sum":
+    if plan.operation in ("groupby_sum", "groupby_avg"):
         if tg == "none" and not plan.group_by:
-            raise AnalyticsPlanValidationError("groupby_sum requires group_by")
+            raise AnalyticsPlanValidationError(f"{plan.operation} requires group_by")
         if plan.group_by and plan.group_by not in visible_columns:
             raise AnalyticsPlanValidationError(
                 f"group_by column '{plan.group_by}' not found in columns"

--- a/backend/services/chat/prompts.py
+++ b/backend/services/chat/prompts.py
@@ -59,7 +59,7 @@ def build_analytics_system_prompt(
         "   {\n"
         '     "document_id": "...",\n'
         '     "operation": "<one of: count_rows, count_distinct, sum, avg, min, max, '
-        'groupby_count, groupby_sum, groupby_ratio, select_rows>",\n'
+        'groupby_count, groupby_sum, groupby_avg, groupby_ratio, select_rows>",\n'
         '     "target_column": "<column name or null>",\n'
         '     "denominator_column": "<for groupby_ratio only; column name or null>",\n'
         '     "group_by": "<column name or null>",\n'
@@ -80,10 +80,10 @@ def build_analytics_system_prompt(
         '              month_equals (value: "YYYY-MM", e.g. "2020-03"),\n'
         '              between_dates (value: ["YYYY-MM-DD", "YYYY-MM-DD"])\n'
         "   - Any:     is_null, is_not_null\n"
-        "6. target_column is REQUIRED for count_distinct, sum, avg, min, max, groupby_sum, groupby_ratio.\n"
+        "6. target_column is REQUIRED for count_distinct, sum, avg, min, max, groupby_sum, groupby_avg, groupby_ratio.\n"
         "7. groupby_ratio: target_column = numerator, denominator_column = denominator, "
         "group_by = dimension (e.g. profit margin by category → SUM(profit)/SUM(revenue) per category).\n"
-        "8. group_by is REQUIRED for groupby_sum (unless using time_grain alone), groupby_ratio, "
+        "8. group_by is REQUIRED for groupby_sum, groupby_avg (unless using time_grain alone), groupby_ratio, "
         "and groupby_count (unless using time_grain without a category).\n"
         "9. time_grain: use month/year/week with time_column (a date column) for "
         "monthly sales, seasonality, trends over time. With group_by, you get buckets per period and category.\n"
@@ -91,6 +91,10 @@ def build_analytics_system_prompt(
         "11. Use select_rows when the user asks to LIST, SHOW, FIND, or GET specific rows or data.\n"
         "12. For 'highest/lowest sum/total <metric> by <dimension>', use groupby_sum with "
         "target_column=<metric>, group_by=<dimension>, set top_n (e.g. 5 for top 5), order=value_desc or value_asc.\n"
+        "12b. For 'average <metric> by <dimension>', 'mean <metric> per <dimension>', or "
+        "'which <dimension> has the highest/lowest/min/max average <metric>', use **groupby_avg** with "
+        "target_column=<metric>, group_by=<dimension>. Use order=value_asc for lowest/min average, "
+        "order=value_desc for highest/max average.\n"
         "13. Column names must be ORIGINAL Excel header names from the list below.\n"
         "14. document_id must be: " + json.dumps(document_id) + "\n"
         "15. For select_rows, set limit to the exact number of rows the user asked for "

--- a/tests/test_analytics_deterministic.py
+++ b/tests/test_analytics_deterministic.py
@@ -1088,6 +1088,191 @@ def test_format_markdown_time_bucket_value_columns():
 
 
 # ============================================================================
+# groupby_avg — compiler, validator, end-to-end
+# ============================================================================
+
+
+class TestGroupbyAvgCompiler:
+    def _col_meta(self) -> dict[str, ColumnMetadata]:
+        return {
+            "Warehouse": ColumnMetadata(
+                column_name="Warehouse",
+                logical_type="string", sqlite_type="TEXT", nullable=True,
+                original_name="Warehouse", safe_name="col_warehouse",
+            ),
+            "LeadTimeDays": ColumnMetadata(
+                column_name="LeadTimeDays",
+                logical_type="integer", sqlite_type="INTEGER", nullable=True,
+                original_name="LeadTimeDays", safe_name="col_lead_time_days",
+            ),
+        }
+
+    def test_groupby_avg_sql(self):
+        plan = AnalyticsPlan(
+            document_id="doc1",
+            operation="groupby_avg",
+            target_column="LeadTimeDays",
+            group_by="Warehouse",
+            order="value_asc",
+            top_n=1,
+        )
+        result = compile_plan(plan, table_name="t1", column_metadata=self._col_meta())
+        assert "AVG(col_lead_time_days) AS value" in result.sql
+        assert "GROUP BY col_warehouse" in result.sql
+        assert "ORDER BY value ASC" in result.sql
+        assert "LIMIT 1" in result.sql
+
+    def test_groupby_avg_value_desc(self):
+        plan = AnalyticsPlan(
+            document_id="doc1",
+            operation="groupby_avg",
+            target_column="LeadTimeDays",
+            group_by="Warehouse",
+            order="value_desc",
+            top_n=5,
+        )
+        result = compile_plan(plan, table_name="t1", column_metadata=self._col_meta())
+        assert "AVG(col_lead_time_days) AS value" in result.sql
+        assert "ORDER BY value DESC" in result.sql
+        assert "LIMIT 5" in result.sql
+
+
+def test_groupby_avg_with_time_grain():
+    col_meta = {
+        "OrderDate": ColumnMetadata(
+            "OrderDate", "date", "INTEGER", True, "OrderDate", "c_od"
+        ),
+        "Cat": ColumnMetadata("Cat", "string", "TEXT", True, "Cat", "c_cat"),
+        "Amount": ColumnMetadata("Amount", "float", "REAL", True, "Amount", "c_amt"),
+    }
+    t_jan = int(datetime(2024, 1, 10, tzinfo=timezone.utc).timestamp())
+    t_feb = int(datetime(2024, 2, 5, tzinfo=timezone.utc).timestamp())
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t (c_od INTEGER, c_cat TEXT, c_amt REAL)")
+    conn.executemany(
+        "INSERT INTO t VALUES (?,?,?)",
+        [
+            (t_jan, "A", 100.0), (t_jan, "A", 200.0),
+            (t_jan, "B", 50.0),
+            (t_feb, "A", 30.0),
+        ],
+    )
+    plan = AnalyticsPlan(
+        document_id="d1",
+        operation="groupby_avg",
+        target_column="Amount",
+        group_by="Cat",
+        time_column="OrderDate",
+        time_grain="month",
+    )
+    validate_plan(plan, col_meta)
+    compiled = compile_plan(plan, table_name="t", column_metadata=col_meta)
+    assert "AVG(c_amt) AS value" in compiled.sql
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(compiled.sql, tuple(compiled.parameters)).fetchall()
+    by_period = {(r["time_bucket"], r["key"]): r["value"] for r in rows}
+    assert by_period[("2024-01", "A")] == pytest.approx(150.0)
+    assert by_period[("2024-01", "B")] == pytest.approx(50.0)
+    assert by_period[("2024-02", "A")] == pytest.approx(30.0)
+
+
+def test_validator_rejects_groupby_avg_missing_group_by():
+    col_meta = {
+        "Amount": ColumnMetadata(
+            "Amount", "float", "REAL", True, "Amount", "col_amount"
+        ),
+    }
+    plan = AnalyticsPlan(
+        document_id="d1",
+        operation="groupby_avg",
+        target_column="Amount",
+    )
+    with pytest.raises(AnalyticsPlanValidationError):
+        validate_plan(plan, col_meta)
+
+
+def test_validator_rejects_groupby_avg_non_numeric_target():
+    col_meta = {
+        "Country": ColumnMetadata(
+            "Country", "string", "TEXT", True, "Country", "col_country"
+        ),
+        "Warehouse": ColumnMetadata(
+            "Warehouse", "string", "TEXT", True, "Warehouse", "col_warehouse"
+        ),
+    }
+    plan = AnalyticsPlan(
+        document_id="d1",
+        operation="groupby_avg",
+        target_column="Country",
+        group_by="Warehouse",
+    )
+    with pytest.raises(AnalyticsPlanValidationError):
+        validate_plan(plan, col_meta)
+
+
+class TestGroupbyAvgEndToEnd(TestEndToEnd):
+    def test_groupby_avg_warehouse_lead_time(self, in_memory_db):
+        """Key scenario: which warehouse has the lowest average lead time."""
+        df = pd.DataFrame([
+            {"Warehouse": "WH-Rome", "LeadTimeDays": 4},
+            {"Warehouse": "WH-Rome", "LeadTimeDays": 6},
+            {"Warehouse": "WH-Rome", "LeadTimeDays": 8},
+            {"Warehouse": "WH-Berlin", "LeadTimeDays": 2},
+            {"Warehouse": "WH-Berlin", "LeadTimeDays": 3},
+            {"Warehouse": "WH-Berlin", "LeadTimeDays": 1},
+            {"Warehouse": "WH-Tokyo", "LeadTimeDays": 5},
+            {"Warehouse": "WH-Tokyo", "LeadTimeDays": 5},
+        ])
+        doc_id, table_name, col_meta = self._ingest_sample(in_memory_db, df)
+        in_memory_db.row_factory = sqlite3.Row
+
+        plan = AnalyticsPlan(
+            document_id=doc_id,
+            operation="groupby_avg",
+            target_column="LeadTimeDays",
+            group_by="Warehouse",
+            order="value_asc",
+            top_n=1,
+        )
+        validate_plan(plan, col_meta)
+        compiled = compile_plan(plan, table_name=table_name, column_metadata=col_meta)
+        rows = in_memory_db.execute(compiled.sql, tuple(compiled.parameters)).fetchall()
+
+        assert len(rows) == 1
+        assert rows[0]["key"] == "WH-Berlin"
+        assert rows[0]["value"] == pytest.approx(2.0)
+
+    def test_groupby_avg_all_warehouses(self, in_memory_db):
+        """Verify all per-group averages are correct."""
+        df = pd.DataFrame([
+            {"Warehouse": "WH-Rome", "LeadTimeDays": 4},
+            {"Warehouse": "WH-Rome", "LeadTimeDays": 6},
+            {"Warehouse": "WH-Berlin", "LeadTimeDays": 2},
+            {"Warehouse": "WH-Berlin", "LeadTimeDays": 4},
+            {"Warehouse": "WH-Tokyo", "LeadTimeDays": 10},
+        ])
+        doc_id, table_name, col_meta = self._ingest_sample(in_memory_db, df)
+        in_memory_db.row_factory = sqlite3.Row
+
+        plan = AnalyticsPlan(
+            document_id=doc_id,
+            operation="groupby_avg",
+            target_column="LeadTimeDays",
+            group_by="Warehouse",
+            order="value_asc",
+            top_n=50,
+        )
+        compiled = compile_plan(plan, table_name=table_name, column_metadata=col_meta)
+        rows = in_memory_db.execute(compiled.sql, tuple(compiled.parameters)).fetchall()
+
+        by_key = {r["key"]: r["value"] for r in rows}
+        assert by_key["WH-Berlin"] == pytest.approx(3.0)
+        assert by_key["WH-Rome"] == pytest.approx(5.0)
+        assert by_key["WH-Tokyo"] == pytest.approx(10.0)
+        assert rows[0]["key"] == "WH-Berlin"
+
+
+# ============================================================================
 # strip_filename_from_query (analytics decomposer pre-processing)
 # ============================================================================
 


### PR DESCRIPTION
- Added support for the new `groupby_avg` operation in the analytics executor, allowing for average calculations grouped by specified columns.
- Updated the query decomposer and SQL compiler to handle `groupby_avg`, including necessary validation for target and group_by parameters.
- Enhanced documentation and prompts to reflect the addition of `groupby_avg`, ensuring clarity on its usage.
- Introduced comprehensive tests for `groupby_avg`, covering SQL compilation, validation, and end-to-end scenarios to ensure functionality and correctness.